### PR TITLE
Change handling of lat/lng validations (warning emails sent to admins instead of errors sent to users), and several bug fixes

### DIFF
--- a/whispersapi/filters.py
+++ b/whispersapi/filters.py
@@ -1,6 +1,6 @@
 from django.db.models import Count
 from django.db.models.functions import Now
-from django_filters.rest_framework import FilterSet, BaseInFilter, NumberFilter, CharFilter, BooleanFilter, ChoiceFilter, DateFilter
+from django_filters.rest_framework import FilterSet, BaseInFilter, NumberFilter, CharFilter, BooleanFilter, MultipleChoiceFilter, DateFilter
 from django_filters.widgets import BooleanWidget
 from rest_framework.exceptions import NotFound
 from whispersapi.models import *
@@ -12,6 +12,10 @@ LIST_DELIMITER = ','
 
 
 class NumberInFilter(BaseInFilter, NumberFilter):
+    pass
+
+
+class CharInFilter(BaseInFilter, CharFilter):
     pass
 
 
@@ -165,10 +169,11 @@ class SearchFilter(FilterSet):
 #     while all other labels (like diagnosis) are assigned to variables
 #       e.g., complete = BooleanFilter(field_name='complete', lookup_expr='exact', label=event.complete)
 class EventSummaryFilter(FilterSet):
-    AND_PARAMS = (('diagnosis', 'diagnosis'), ('diagnosis_type', 'diagnosis_type'), ('species', 'species'),
-                  ('administrative_level_one', 'administrative_level_one'),
-                  ('administrative_level_two', 'administrative_level_two'), )
-    PERMISSION_SOURCES = (('own', 'own'), ('organization', 'organization'), ('collaboration', 'collaboration'), )
+    AND_PARAMS_ENUM = (('diagnosis', 'diagnosis'), ('diagnosis_type', 'diagnosis_type'), ('species', 'species'),
+                       ('administrative_level_one', 'administrative_level_one'),
+                       ('administrative_level_two', 'administrative_level_two'),
+                       )
+    PERMISSION_SOURCES_ENUM = (('own', 'own'), ('organization', 'organization'), ('collaboration', 'collaboration'), )
 
     # do nothing, as this query param is not an independent filter on any fields,
     #  but a 'meta' filter for changing how other filters are used in combination
@@ -224,13 +229,14 @@ class EventSummaryFilter(FilterSet):
                 queryset = queryset.prefetch_related('eventdiagnoses').filter(
                     eventdiagnoses__diagnosis__in=diagnosis_list).distinct()
                 parser_context = getattr(self.request, 'parser_context', None)
-                and_params = parser_context['kwargs'].get('and_params', None) if parser_context else None
+                and_params = parser_context['request'].query_params.get('and_params', None) if parser_context else None
                 if and_params is not None and 'diagnosis' in and_params:
                     # first, count the species for each returned event
                     # and only allow those with the same or greater count as the length of the query_param list
+                    # use the 'only' operator to avoid PostgreSQL GROUP BY errors in annotation aggregation
                     queryset = queryset.annotate(count_diagnoses=Count(
                         'eventdiagnoses__diagnosis', distinct=True)).filter(
-                        count_diagnoses__gte=len(diagnosis_list))
+                        count_diagnoses__gte=len(diagnosis_list)).only('id')
                     diagnosis_list_ints = [int(i) for i in diagnosis_list]
                     # next, find only the events that have _all_ the requested values, not just any of them
                     for item in queryset:
@@ -252,13 +258,14 @@ class EventSummaryFilter(FilterSet):
                 queryset = queryset.prefetch_related('eventdiagnoses__diagnosis__diagnosis_type').filter(
                     eventdiagnoses__diagnosis__diagnosis_type__in=diagnosis_type_list).distinct()
                 parser_context = getattr(self.request, 'parser_context', None)
-                and_params = parser_context['kwargs'].get('and_params', None) if parser_context else None
+                and_params = parser_context['request'].query_params.get('and_params', None) if parser_context else None
                 if and_params is not None and 'diagnosis_type' in and_params:
                     # first, count the species for each returned event
                     # and only allow those with the same or greater count as the length of the query_param list
+                    # use the 'only' operator to avoid PostgreSQL GROUP BY errors in annotation aggregation
                     queryset = queryset.annotate(count_diagnosis_types=Count(
                         'eventdiagnoses__diagnosis__diagnosis_type', distinct=True)).filter(
-                        count_diagnosis_types__gte=len(diagnosis_type_list))
+                        count_diagnosis_types__gte=len(diagnosis_type_list)).only('id')
                     diagnosis_type_list_ints = [int(i) for i in diagnosis_type_list]
                     # next, find only the events that have _all_ the requested values, not just any of them
                     for item in queryset:
@@ -280,12 +287,14 @@ class EventSummaryFilter(FilterSet):
                 queryset = queryset.prefetch_related('eventlocations__locationspecies__species').filter(
                     eventlocations__locationspecies__species__in=species_list).distinct()
                 parser_context = getattr(self.request, 'parser_context', None)
-                and_params = parser_context['kwargs'].get('and_params', None) if parser_context else None
+                and_params = parser_context['request'].query_params.get('and_params', None) if parser_context else None
                 if and_params is not None and 'species' in and_params:
                     # first, count the species for each returned event
                     # and only allow those with the same or greater count as the length of the query_param list
+                    # use the 'only' operator to avoid PostgreSQL GROUP BY errors in annotation aggregation
                     queryset = queryset.annotate(count_species=Count(
-                        'eventlocations__locationspecies__species')).filter(count_species__gte=len(species_list))
+                        'eventlocations__locationspecies__species')).filter(
+                        count_species__gte=len(species_list)).only('id')
                     species_list_ints = [int(i) for i in species_list]
                     # next, find only the events that have _all_ the requested values, not just any of them
                     for item in queryset:
@@ -308,7 +317,7 @@ class EventSummaryFilter(FilterSet):
                 queryset = queryset.prefetch_related('eventlocations__administrative_level_two').filter(
                     eventlocations__administrative_level_one__in=admin_level_one_list).distinct()
                 parser_context = getattr(self.request, 'parser_context', None)
-                and_params = parser_context['kwargs'].get('and_params', None) if parser_context else None
+                and_params = parser_context['request'].query_params.get('and_params', None) if parser_context else None
                 if and_params is not None and 'administrative_level_one' in and_params:
                     # this _should_ be fairly straight forward with the postgresql ArrayAgg function,
                     # (which would offload the hard work to postgresql and make this whole operation faster)
@@ -317,8 +326,10 @@ class EventSummaryFilter(FilterSet):
 
                     # first, count the eventlocations for each returned event
                     # and only allow those with the same or greater count as the length of the query_param list
+                    # use the 'only' operator to avoid PostgreSQL GROUP BY errors in annotation aggregation
                     queryset = queryset.annotate(
-                        count_evtlocs=Count('eventlocations')).filter(count_evtlocs__gte=len(admin_level_one_list))
+                        count_evtlocs=Count('eventlocations')).filter(
+                        count_evtlocs__gte=len(admin_level_one_list)).only('id')
                     admin_level_one_list_ints = [int(i) for i in admin_level_one_list]
                     # next, find only the events that have _all_ the requested values, not just any of them
                     for item in queryset:
@@ -341,12 +352,14 @@ class EventSummaryFilter(FilterSet):
                 queryset = queryset.prefetch_related('eventlocations__administrative_level_two').filter(
                     eventlocations__administrative_level_two__in=admin_level_two_list).distinct()
                 parser_context = getattr(self.request, 'parser_context', None)
-                and_params = parser_context['kwargs'].get('and_params', None) if parser_context else None
+                and_params = parser_context['request'].query_params.get('and_params', None) if parser_context else None
                 if and_params is not None and 'administrative_level_two' in and_params:
                     # first, count the eventlocations for each returned event
                     # and only allow those with the same or greater count as the length of the query_param list
+                    # use the 'only' operator to avoid PostgreSQL GROUP BY errors in annotation aggregation
                     queryset = queryset.annotate(
-                        count_evtlocs=Count('eventlocations')).filter(count_evtlocs__gte=len(admin_level_two_list))
+                        count_evtlocs=Count('eventlocations')).filter(
+                        count_evtlocs__gte=len(admin_level_two_list)).only('id')
                     admin_level_two_list_ints = [int(i) for i in admin_level_two_list]
                     # next, find only the events that have _all_ the requested values, not just any of them
                     for item in queryset:
@@ -384,26 +397,26 @@ class EventSummaryFilter(FilterSet):
             queryset = queryset.filter(start_date__lte=end_date)
         return queryset
 
-    # TODO: add label arguments to filters to prevent [invalid_name] displaying in filter form
+    # label arguments were added to filters to prevent [invalid_name] displaying in filter form
     # https://github.com/carltongibson/django-filter/issues/1009
-    and_params = ChoiceFilter(choices=AND_PARAMS, method='filter_and_params')
+    and_params = CharInFilter(method='filter_and_params', label='Set the fields that will be combined with an "AND" operator instead of the default "OR"')
     complete = BooleanFilter(label='Filter by whether event is complete or not')
     public = BooleanFilter(label='Filter by whether event is public or not')
-    permission_source = ChoiceFilter(choices=PERMISSION_SOURCES, method='filter_permission_sources')
-    event_type = NumberInFilter(lookup_expr='in')
-    diagnosis = NumberInFilter(method='filter_diagnosis')
-    diagnosis_type = NumberInFilter(method='filter_diagnosis_type')
-    species = NumberInFilter(method='filter_species')
-    administrative_level_one = NumberInFilter(method='filter_administrative_level_one')
-    administrative_level_two = NumberInFilter(method='filter_administrative_level_two')
-    flyway = NumberInFilter(field_name='eventlocations__flyway', lookup_expr='in')
-    country = NumberInFilter(field_name='eventlocations__country', lookup_expr='in')
-    gnis_id = NumberInFilter(field_name='eventlocations__gnis_id', lookup_expr='in')
-    affected_count__gte = NumberFilter(field_name='affected_count', lookup_expr='gte')
-    affected_count__lte = NumberFilter(field_name='affected_count', lookup_expr='lte')
-    start_date = DateFilter(method='filter_start_end_date')
-    end_date = DateFilter(method='filter_start_end_date')
-    id = NumberInFilter(lookup_expr='in')
+    permission_source = MultipleChoiceFilter(choices=PERMISSION_SOURCES_ENUM, method='filter_permission_sources', label='Filter by how the user has permission to view events')
+    event_type = NumberInFilter(lookup_expr='in', label='Filter by event type ID (or a list of event type IDs)')
+    diagnosis = NumberInFilter(method='filter_diagnosis', label='Filter by diagnosis ID (or a list of diagnosis IDs)')
+    diagnosis_type = NumberInFilter(method='filter_diagnosis_type', label='Filter by diagnosis type ID (or a list of diagnosis type IDs)')
+    species = NumberInFilter(method='filter_species', label='Filter by species ID (or a list of species IDs)')
+    administrative_level_one = NumberInFilter(method='filter_administrative_level_one', label='Filter by administrative level one (e.g., state) ID (or a list of administrative level one (e.g., state) IDs)')
+    administrative_level_two = NumberInFilter(method='filter_administrative_level_two', label='Filter by administrative level two (e.g., county) ID (or a list of administrative level two (e.g., county) IDs)')
+    flyway = NumberInFilter(field_name='eventlocations__flyway', lookup_expr='in', label='Filter by flyway ID (or a list of flyway IDs)')
+    country = NumberInFilter(field_name='eventlocations__country', lookup_expr='in', label='Filter by country ID (or a list of country IDs)')
+    gnis_id = NumberInFilter(field_name='eventlocations__gnis_id', lookup_expr='in', label='Filter by GNIS ID (or a list of GNIS IDs)')
+    affected_count__gte = NumberFilter(field_name='affected_count', lookup_expr='gte', label='Filter by affected count (greater than or equal to)')
+    affected_count__lte = NumberFilter(field_name='affected_count', lookup_expr='lte', label='Filter by affected count (less than or equal to)')
+    start_date = DateFilter(method='filter_start_end_date', label='Filter by start date', help_text='YYYY-MM-DD format')
+    end_date = DateFilter(method='filter_start_end_date', label='Filter by end date', help_text='YYYY-MM-DD format')
+    id = NumberInFilter(lookup_expr='in', label='Filter by event ID (or a list of event IDs)')
 
     class Meta:
         model = Event

--- a/whispersapi/scheduled_tasks.py
+++ b/whispersapi/scheduled_tasks.py
@@ -22,7 +22,7 @@ def get_nwhc_org_id():
 
 
 def get_yesterday():
-    return datetime.strftime(datetime.now() - timedelta(days=5), '%Y-%m-%d')
+    return datetime.strftime(datetime.now() - timedelta(days=1), '%Y-%m-%d')
 
 
 def get_change_info(history_record, model_name):

--- a/whispersapi/scheduled_tasks.py
+++ b/whispersapi/scheduled_tasks.py
@@ -6,21 +6,23 @@ from whispersapi.models import *
 from whispersapi.immediate_tasks import *
 
 
-nwhc_org_record = Configuration.objects.filter(name='nwhc_organization').first()
-if nwhc_org_record:
-    if nwhc_org_record.value.isdecimal():
-        NWHC_ORG_ID = int(nwhc_org_record.value)
+def get_nwhc_org_id():
+    nwhc_org_record = Configuration.objects.filter(name='nwhc_organization').first()
+    if nwhc_org_record:
+        if nwhc_org_record.value.isdecimal():
+            NWHC_ORG_ID = int(nwhc_org_record.value)
+        else:
+            NWHC_ORG_ID = settings.NWHC_ORG_ID
+            encountered_type = type(nwhc_org_record.value).__name__
+            send_wrong_type_configuration_value_email('nwhc_organization', encountered_type, 'int')
     else:
         NWHC_ORG_ID = settings.NWHC_ORG_ID
-        encountered_type = type(nwhc_org_record.value).__name__
-        send_wrong_type_configuration_value_email('nwhc_organization', encountered_type, 'int')
-else:
-    NWHC_ORG_ID = settings.NWHC_ORG_ID
-    send_missing_configuration_value_email('nwhc_organization')
+        send_missing_configuration_value_email('nwhc_organization')
+    return NWHC_ORG_ID
 
 
 def get_yesterday():
-    return datetime.strftime(datetime.now() - timedelta(days=1), '%Y-%m-%d')
+    return datetime.strftime(datetime.now() - timedelta(days=5), '%Y-%m-%d')
 
 
 def get_change_info(history_record, model_name):
@@ -76,6 +78,7 @@ def get_change_info(history_record, model_name):
 def get_changes(history, source_id, yesterday, model_name, source_type, cue_user):
     yesterday_date = datetime.strptime(yesterday, '%Y-%m-%d').date()
     changes = ""
+    NWHC_OG_ID = get_nwhc_org_id()
 
     if len(history) == 0:
         # no history records for the model, so ignore
@@ -113,7 +116,7 @@ def get_changes(history, source_id, yesterday, model_name, source_type, cue_user
                 pass
             elif model_name == 'event_group_comment':
                 if not (cue_user.role.is_superadmin or cue_user.role.is_admin
-                          or cue_user.organization.id == NWHC_ORG_ID):
+                          or cue_user.organization.id == NWHC_OG_ID):
                     # Event Group comments visible only to NWHC staff
                     pass
             else:
@@ -159,7 +162,7 @@ def get_changes(history, source_id, yesterday, model_name, source_type, cue_user
                         continue
                     elif model_name == 'event_group_comment':
                         if not (cue_user.role.is_superadmin or cue_user.role.is_admin
-                                  or cue_user.organization.id == NWHC_ORG_ID):
+                                or cue_user.organization.id == NWHC_OG_ID):
                             # Event Group comments visible only to NWHC staff
                             # keep loop going in case changes made by this updater are interspersed among other changes
                             continue
@@ -195,16 +198,14 @@ def get_changes(history, source_id, yesterday, model_name, source_type, cue_user
                                         continue
                                 elif fld == 'staff':
                                     # check permissions (visible to NWHC only!)
-                                    if (cue_user.id == h.created_by.id
-                                            or cue_user.organization.id == h.created_by.organization.id):
+                                    if cue_user.organization.id == NWHC_OG_ID:
                                         change.new = Staff.objects.get(id=change.new) if change.new else change.new
                                         change.old = Staff.objects.get(id=change.old) if change.old else change.old
                                     else:
                                         continue
                                 elif fld == 'event_status':
                                     # check permissions (visible to NWHC only!)
-                                    if (cue_user.id == h.created_by.id
-                                            or cue_user.organization.id == h.created_by.organization.id):
+                                    if cue_user.organization.id == NWHC_OG_ID:
                                         chg = change
                                         change.new = EventStatus.objects.get(id=chg.new) if chg.new else chg.new
                                         change.old = EventStatus.objects.get(id=chg.old) if chg.old else chg.old
@@ -212,16 +213,14 @@ def get_changes(history, source_id, yesterday, model_name, source_type, cue_user
                                         continue
                                 elif fld == 'quality_check':
                                     # check permissions (visible to NWHC only!)
-                                    if (cue_user.id == h.created_by.id
-                                            or cue_user.organization.id == h.created_by.organization.id):
+                                    if cue_user.organization.id == NWHC_OG_ID:
                                         change.new = "\"\"" if change.new == '' else change.new
                                         change.old = "\"\"" if change.old == '' else change.old
                                     else:
                                         continue
                                 elif fld == 'legal_status':
                                     # check permissions (visible to NWHC only!)
-                                    if (cue_user.id == h.created_by.id
-                                            or cue_user.organization.id == h.created_by.organization.id):
+                                    if cue_user.organization.id == NWHC_OG_ID:
                                         chg = change
                                         change.new = LegalStatus.objects.get(id=chg.new) if chg.new else chg.new
                                         change.old = LegalStatus.objects.get(id=chg.old) if chg.old else chg.old
@@ -229,8 +228,7 @@ def get_changes(history, source_id, yesterday, model_name, source_type, cue_user
                                         continue
                                 elif fld == 'legal_number':
                                     # check permissions (visible to NWHC only!)
-                                    if (cue_user.id == h.created_by.id
-                                            or cue_user.organization.id == h.created_by.organization.id):
+                                    if cue_user.organization.id == NWHC_OG_ID:
                                         change.new = "\"\"" if change.new == '' else change.new
                                         change.old = "\"\"" if change.old == '' else change.old
                                     else:
@@ -566,9 +564,6 @@ def get_event_notifications_own_updated(events_updated_yesterday, yesterday, use
 
     elif cue.notification_cue_preference.create_when_modified:
         for event in events_updated_yesterday:
-            if event.id == 170903:
-                print("get_event_notifications_organization_updated for 170902")
-                print(event.id, cue.id, cue.created_by.id)
             # Create one notification per distinct updater (not including the creator)
             # django_simple_history.history_type: + for create, ~ for update, and - for delete
             event_updater_ids = list(set(
@@ -616,9 +611,6 @@ def get_event_notifications_organization_updated(events_updated_yesterday, yeste
 
     elif cue.notification_cue_preference.create_when_modified:
         for event in events_updated_yesterday:
-            if event.id == 170902:
-                print("get_event_notifications_organization_updated for 170902")
-                print(event.id, cue.id, cue.created_by.id)
             # Create one notification per distinct updater (not including the creator)
             # django_simple_history.history_type: + for create, ~ for update, and - for delete
             event_updater_ids = list(set(
@@ -927,7 +919,7 @@ def standard_notifications_by_user(new_event_count, updated_event_count, yesterd
                 send_unique_notifications(own_notifs, org_notifs, collab_notifs, all_notifs)
 
     except SoftTimeLimitExceeded:
-        recip = EMAIL_WHISPERS
+        recip = get_whispers_email_address()
         subject = "WHISPERS ADMIN: Timeout Encountered During standard_notifications_by_user_task"
         body = "A timeout was encountered while generating standard notifications for user "
         body += user.first_name + " " + user.last_name + " (username " + user.username + ", ID " + str(user.id) + ")."
@@ -960,7 +952,7 @@ def standard_notifications():
                 standard_notifications_by_user.delay(new_event_count, updated_event_count, yesterday, user_id)
 
     except SoftTimeLimitExceeded:
-        recip = EMAIL_WHISPERS
+        recip = get_whispers_email_address()
         subject = "WHISPERS ADMIN: Timeout Encountered During standard_notifications_task"
         body = "A timeout was encountered while generating standard notifications."
         body += " Some notifications may have been created before the task timed out."
@@ -1389,7 +1381,7 @@ def custom_notifications_by_user(yesterday, user_id):
                                                                     body, send_email, email_to)
 
     except SoftTimeLimitExceeded:
-        recip = EMAIL_WHISPERS
+        recip = get_whispers_email_address()
         subject = "WHISPERS ADMIN: Timeout Encountered During custom_notifications_by_user_task"
         body = "A timeout was encountered while generating custom notifications for user "
         body += user.first_name + " " + user.last_name + " (username " + user.username + ", ID " + str(user.id) + ")."
@@ -1414,7 +1406,7 @@ def custom_notifications():
         for user_id in active_user_ids:
             custom_notifications_by_user.delay(yesterday, user_id)
     except SoftTimeLimitExceeded:
-        recip = EMAIL_WHISPERS
+        recip = get_whispers_email_address()
         subject = "WHISPERS ADMIN: Timeout Encountered During custom_notifications_task"
         body = "A timeout was encountered while generating custom notifications."
         body += " Some notifications may have been created before the task timed out."

--- a/whispersapi/serializers.py
+++ b/whispersapi/serializers.py
@@ -710,26 +710,8 @@ class EventSerializer(serializers.ModelSerializer):
                     # geonames_endpoint = 'extendedFindNearbyJSON'
                     # GEONAMES_USERNAME = get_geonames_username()
                     # GEONAMES_API = get_geonames_api()
-                    # if ('latitude' in item and item['latitude'] is not None
-                    #         and 'longitude' in item and item['longitude'] is not None):
-                    #     payload = {'lat': item['latitude'], 'lng': item['longitude'],
-                    #                'username': GEONAMES_USERNAME}
-                    #     r = requests.get(GEONAMES_API + geonames_endpoint, params=payload, verify=settings.SSL_CERT)
-                    #     try:
-                    #         content = decode_json(r)
-                    #         if 'address' not in content and 'geonames' not in content:
-                    #             # Instead of causing a validation error, email admins and let the create proceed
-                    #             # latlng_is_valid = False
-                    #             message = f"Geonames returned data in an unexpected format"
-                    #             message += " that could not be validated against data in the WHISPers database"
-                    #             message += f" when using the latitude and longitude submitted by the user"
-                    #             message += f" ({data['longitude']}, {data['latitude']})."
-                    #             message += f" The request made to Geonames was: {r.request.url}"
-                    #             construct_email("WHISPERS ADMIN: Third Party Service Validation Warning", message)
-                    #     except requests.exceptions.RequestException as e:
-                    #         # email admins
-                    #         send_third_party_service_exception_email('Geonames', GEONAMES_API + geonames_endpoint, e)
-                    # if (latlng_is_valid and 'latitude' in item and item['latitude'] is not None
+                    # if (latlng_is_valid
+                    #         and 'latitude' in item and item['latitude'] is not None
                     #         and 'longitude' in item and item['longitude'] is not None
                     #         and 'country' in item and item['country'] is not None):
                     #     payload = {'lat': item['latitude'], 'lng': item['longitude'], 'username': GEONAMES_USERNAME}
@@ -2103,26 +2085,8 @@ class EventLocationSerializer(serializers.ModelSerializer):
                 geonames_endpoint = 'extendedFindNearbyJSON'
                 GEONAMES_USERNAME = get_geonames_username()
                 GEONAMES_API = get_geonames_api()
-                if ('latitude' in data and data['latitude'] is not None
-                        and 'longitude' in data and data['longitude'] is not None):
-                    payload = {'lat': data['latitude'], 'lng': data['longitude'], 'username': GEONAMES_USERNAME}
-                    r = requests.get(GEONAMES_API + geonames_endpoint, params=payload, verify=settings.SSL_CERT)
-                    try:
-                        content = decode_json(r)
-                        if 'address' not in content and 'geonames' not in content:
-                            # Instead of causing a validation error, email admins and let the create proceed
-                            # latlng_is_valid = False
-                            message = f"Geonames returned data in an unexpected format"
-                            message += " that could not be validated against data in the WHISPers database"
-                            message += f" when using the latitude and longitude submitted by the user"
-                            message += f" ({data['longitude']}, {data['latitude']})."
-                            message += f" The request made to Geonames was: {r.request.url}"
-                            construct_email("WHISPERS ADMIN: Third Party Service Validation Warning", message)
-                    except requests.exceptions.RequestException as e:
-                        # email admins
-                        send_third_party_service_exception_email('Geonames', GEONAMES_API + geonames_endpoint, e)
-                        # latlng_is_valid = False
-                if (latlng_is_valid and 'latitude' in data and data['latitude'] is not None
+                if (latlng_is_valid
+                        and 'latitude' in data and data['latitude'] is not None
                         and 'longitude' in data and data['longitude'] is not None
                         and 'country' in data and data['country'] is not None):
                     payload = {'lat': data['latitude'], 'lng': data['longitude'], 'username': GEONAMES_USERNAME}

--- a/whispersapi/serializers.py
+++ b/whispersapi/serializers.py
@@ -789,9 +789,9 @@ class EventSerializer(serializers.ModelSerializer):
                                         # latlng_matches_admin_21 = False
                                         message = f"Geonames returned an Administrative Level Two name ({admin_name2})"
                                         message += " different from the one submitted by the user"
-                                        message += f" ({data['administrative_level_two'].name}) when using the latitude"
+                                        message += f" ({admin_l2.name}) when using the latitude"
                                         message += " and longitude submitted by the user"
-                                        message += f" ({data['longitude']}, {data['latitude']})."
+                                        message += f" ({item['longitude']}, {item['latitude']})."
                                         message += f" The request made to Geonames was: {geonames_latlng_url}"
                                         construct_email("WHISPERS ADMIN: Third Party Service Validation Warning",
                                                         message)
@@ -2134,7 +2134,7 @@ class EventLocationSerializer(serializers.ModelSerializer):
                                     # latlng_matches_admin_21 = False
                                     message = f"Geonames returned an Administrative Level Two name ({admin_name2})"
                                     message += " different from the one submitted by the user"
-                                    message += f" ({data['administrative_level_two'].name}) when using the latitude"
+                                    message += f" ({admin_l2.name}) when using the latitude"
                                     message += " and longitude submitted by the user"
                                     message += f" ({data['longitude']}, {data['latitude']}).\r\n"
                                     message += f" The request made to Geonames was: {geonames_latlng_url}"

--- a/whispersapi/serializers.py
+++ b/whispersapi/serializers.py
@@ -5055,37 +5055,7 @@ class EventSummarySerializer(serializers.ModelSerializer):
     organizations = OrganizationSerializer(many=True)
     permissions = DRYPermissionsField()
     permission_source = serializers.SerializerMethodField()
-    species_most_affected = serializers.SerializerMethodField()
 
-    def get_species_most_affected(self, obj, *args, **kwargs):
-        species_most_affected = None
-        unique_species_ids = []
-        unique_species = []
-        species_counts = {}
-        eventlocations = obj.eventlocations.values()
-        if eventlocations is not None:
-            for eventlocation in eventlocations:
-                locationspecies = LocationSpecies.objects.filter(event_location=eventlocation['id'])
-                if locationspecies is not None:
-                    for locspec in locationspecies:
-                        species = Species.objects.filter(id=locspec.species_id).first()
-                        if species is not None:
-                            sick_count = (locspec.sick_count or 0) + (locspec.sick_count_estimated or 0)
-                            dead_count = (locspec.dead_count or 0) + (locspec.dead_count_estimated or 0)
-                            species_count = sick_count + dead_count
-                            if species.id not in unique_species_ids:
-                                # not yet encountered in the loop
-                                unique_species_ids.append(species.id)
-                                unique_species.append(model_to_dict(species))
-                                species_counts[species.id] = species_count
-                            else:
-                                # already encountered in the loop so add the new count to the existing count
-                                current_species_count = species_counts[species.id]
-                                species_counts[species.id] = current_species_count + species_count
-            # find the highest count
-            species_most_affected_id = max(species_counts, key=(lambda key: species_counts[key]))
-            species_most_affected = model_to_dict(Species.objects.filter(id=species_most_affected_id).first())
-        return species_most_affected
 
     def get_eventdiagnoses(self, obj, *args, **kwargs):
         user = None
@@ -5198,19 +5168,19 @@ class EventSummarySerializer(serializers.ModelSerializer):
         fields = ('id', 'affected_count', 'start_date', 'end_date', 'complete', 'event_type', 'event_type_string',
                   'event_status', 'event_status_string', 'eventdiagnoses', 'administrativelevelones',
                   'administrativeleveltwos', 'flyways', 'species', 'organizations', 'permissions',
-                  'permission_source', 'species_most_affected',)
+                  'permission_source',)
         private_fields = ('id', 'event_reference', 'affected_count', 'start_date', 'end_date', 'complete', 'event_type',
                           'event_type_string', 'event_status', 'event_status_string', 'public', 'eventdiagnoses',
                           'administrativelevelones', 'administrativeleveltwos', 'flyways', 'species', 'created_date',
                           'created_by', 'created_by_string', 'modified_date', 'modified_by', 'modified_by_string',
-                          'organizations', 'permissions', 'permission_source', 'species_most_affected',)
+                          'organizations', 'permissions', 'permission_source',)
         admin_fields = ('id', 'event_type', 'event_type_string', 'event_reference', 'complete', 'start_date',
                         'end_date', 'affected_count', 'staff', 'staff_string', 'event_status', 'event_status_string',
                         'legal_status', 'legal_status_string', 'legal_number', 'quality_check', 'public', 'eventgroups',
                         'organizations', 'contacts', 'eventdiagnoses', 'administrativelevelones',
                         'administrativeleveltwos', 'flyways', 'species', 'created_date', 'created_by',
                         'created_by_string', 'modified_date', 'modified_by', 'modified_by_string', 'permissions',
-                        'permission_source', 'species_most_affected',)
+                        'permission_source',)
 
         if user and user.is_authenticated:
             if user.role.is_superadmin or user.role.is_admin:

--- a/whispersapi/serializers.py
+++ b/whispersapi/serializers.py
@@ -5055,6 +5055,37 @@ class EventSummarySerializer(serializers.ModelSerializer):
     organizations = OrganizationSerializer(many=True)
     permissions = DRYPermissionsField()
     permission_source = serializers.SerializerMethodField()
+    species_most_affected = serializers.SerializerMethodField()
+
+    def get_species_most_affected(self, obj, *args, **kwargs):
+        species_most_affected = None
+        unique_species_ids = []
+        unique_species = []
+        species_counts = {}
+        eventlocations = obj.eventlocations.values()
+        if eventlocations is not None:
+            for eventlocation in eventlocations:
+                locationspecies = LocationSpecies.objects.filter(event_location=eventlocation['id'])
+                if locationspecies is not None:
+                    for locspec in locationspecies:
+                        species = Species.objects.filter(id=locspec.species_id).first()
+                        if species is not None:
+                            sick_count = (locspec.sick_count or 0) + (locspec.sick_count_estimated or 0)
+                            dead_count = (locspec.dead_count or 0) + (locspec.dead_count_estimated or 0)
+                            species_count = sick_count + dead_count
+                            if species.id not in unique_species_ids:
+                                # not yet encountered in the loop
+                                unique_species_ids.append(species.id)
+                                unique_species.append(model_to_dict(species))
+                                species_counts[species.id] = species_count
+                            else:
+                                # already encountered in the loop so add the new count to the existing count
+                                current_species_count = species_counts[species.id]
+                                species_counts[species.id] = current_species_count + species_count
+            # find the highest count
+            species_most_affected_id = max(species_counts, key=(lambda key: species_counts[key]))
+            species_most_affected = model_to_dict(Species.objects.filter(id=species_most_affected_id).first())
+        return species_most_affected
 
     def get_eventdiagnoses(self, obj, *args, **kwargs):
         user = None
@@ -5167,19 +5198,19 @@ class EventSummarySerializer(serializers.ModelSerializer):
         fields = ('id', 'affected_count', 'start_date', 'end_date', 'complete', 'event_type', 'event_type_string',
                   'event_status', 'event_status_string', 'eventdiagnoses', 'administrativelevelones',
                   'administrativeleveltwos', 'flyways', 'species', 'organizations', 'permissions',
-                  'permission_source',)
+                  'permission_source', 'species_most_affected',)
         private_fields = ('id', 'event_reference', 'affected_count', 'start_date', 'end_date', 'complete', 'event_type',
                           'event_type_string', 'event_status', 'event_status_string', 'public', 'eventdiagnoses',
                           'administrativelevelones', 'administrativeleveltwos', 'flyways', 'species', 'created_date',
                           'created_by', 'created_by_string', 'modified_date', 'modified_by', 'modified_by_string',
-                          'organizations', 'permissions', 'permission_source',)
+                          'organizations', 'permissions', 'permission_source', 'species_most_affected',)
         admin_fields = ('id', 'event_type', 'event_type_string', 'event_reference', 'complete', 'start_date',
                         'end_date', 'affected_count', 'staff', 'staff_string', 'event_status', 'event_status_string',
                         'legal_status', 'legal_status_string', 'legal_number', 'quality_check', 'public', 'eventgroups',
                         'organizations', 'contacts', 'eventdiagnoses', 'administrativelevelones',
                         'administrativeleveltwos', 'flyways', 'species', 'created_date', 'created_by',
                         'created_by_string', 'modified_date', 'modified_by', 'modified_by_string', 'permissions',
-                        'permission_source',)
+                        'permission_source', 'species_most_affected',)
 
         if user and user.is_authenticated:
             if user.role.is_superadmin or user.role.is_admin:

--- a/whispersapi/views.py
+++ b/whispersapi/views.py
@@ -2856,7 +2856,10 @@ class EventSummaryViewSet(ReadOnlyHistoryViewSet):
                 Q(created_by__exact=user.id) | Q(created_by__organization__exact=user.organization.id)
                 | Q(created_by__organization__in=user.organization.child_organizations)
                 | Q(read_collaborators__in=[user.id]) | Q(write_collaborators__in=[user.id])).distinct()
-            queryset = public_queryset | personal_queryset
+            # the pipe operator is supposed to do a union,
+            # but apparently when one queryset is empty the resulting union is also empty, which is not what we want
+            # queryset = public_queryset | personal_queryset
+            queryset = public_queryset.union(personal_queryset)
 
         return queryset
 
@@ -2973,5 +2976,8 @@ class EventDetailViewSet(ReadOnlyHistoryViewSet):
             personal_queryset = queryset.filter(
                 Q(created_by__exact=user.id) | Q(created_by__organization__exact=user.organization.id)
                 | Q(read_collaborators__in=[user.id]) | Q(write_collaborators__in=[user.id])).distinct()
-            queryset = public_queryset | personal_queryset
+            # the pipe operator is supposed to do a union,
+            # but apparently when one queryset is empty the resulting union is also empty, which is not what we want
+            # queryset = public_queryset | personal_queryset
+            queryset = public_queryset.union(personal_queryset)
             return queryset


### PR DESCRIPTION
- Add labels to all EventSummaryFilter fields to prevent [invalid_name] displaying in filter form
- Fix EventSummary and_params query param filter to restore AND operator functionality, following previous refactor to using django-filters package that broke this functionality
- Fix bug caused by queryset pipe operator (union) producing an empty queryset when one source queryset is empty (use q3 = q1.union(q2) method instead)
- Fix bug where NWHC-only event fields were being included in update notifications to event owners outside NWHC
- Fix bug caused by attempted int coercion of None when removing Pending and Undetermined event diagnoses from new events
- Change all lat/lng validation to send emails to admins rather than return errors to users
- Fix typo in county lat/lng validation email, comment out lat/lng validation in Event serializer to prevent two identical emails being sent to admins
- Improve handling of unexpected Geonames responses
- Remove duplicate geonames address validation